### PR TITLE
Fix persistenz beim Löschen von Testknoten im LeftDrawer

### DIFF
--- a/app/src/main/java/de/bund/zrb/ui/LeftDrawer.java
+++ b/app/src/main/java/de/bund/zrb/ui/LeftDrawer.java
@@ -30,6 +30,8 @@ public class LeftDrawer extends JPanel implements TestPlayerUi {
             DefaultTreeModel model = (DefaultTreeModel) testTree.getModel();
             model.removeNodeFromParent(selected);
             model.reload(); // Ensure the tree UI is refreshed after deletion
+            TestTreeModel treeModel = (TestTreeModel) testTree.getModel();
+            treeModel.save(); // Persist the modified tree structure
         }
     }
 


### PR DESCRIPTION
Dieses PR stellt sicher, dass beim Löschen von Testknoten aus dem UI-Baum auch der persistierte Zustand aktualisiert wird. Der Aufruf `treeModel.save()` speichert die geänderte Baumstruktur dauerhaft.

Closes #1.