### PR TITLE
Add precondition validation to scope editors

### DIFF
--- a/app/src/main/java/de/bund/zrb/model/RootNode.java
+++ b/app/src/main/java/de/bund/zrb/model/RootNode.java
@@ -30,6 +30,8 @@ public class RootNode {
     private final Map<String, Boolean> afterEachEnabled = new HashMap<>();
     private final Map<String,String> afterEachDesc = new HashMap<>();
 
+    private List<Precondtion> preconditions = new ArrayList<>();
+
     public RootNode() {
         this.id = java.util.UUID.randomUUID().toString();
     }
@@ -76,6 +78,14 @@ public class RootNode {
 
     public Map<String, String> getAfterEachDesc() {
         return afterEachDesc;
+    }
+
+    public List<Precondtion> getPreconditions() {
+        return preconditions;
+    }
+
+    public void setPreconditions(List<Precondtion> preconditions) {
+        this.preconditions = (preconditions != null) ? preconditions : new ArrayList<Precondtion>();
     }
 }
 

--- a/app/src/main/java/de/bund/zrb/model/TestCase.java
+++ b/app/src/main/java/de/bund/zrb/model/TestCase.java
@@ -26,6 +26,8 @@ public class TestCase {
     private final Map<String, Boolean> afterEnabled = new HashMap<>();
     private final Map<String, String> afterDesc = new HashMap<>();
 
+    private List<Precondtion> preconditions = new ArrayList<Precondtion>();
+
     public TestCase() {}
 
     public TestCase(String name, List<TestAction> when) {
@@ -62,6 +64,14 @@ public class TestCase {
 
     public Map<String, String> getAfterDesc() {
         return afterDesc;
+    }
+
+    public List<Precondtion> getPreconditions() {
+        return preconditions;
+    }
+
+    public void setPreconditions(List<Precondtion> preconditions) {
+        this.preconditions = (preconditions != null) ? preconditions : new ArrayList<Precondtion>();
     }
 }
 

--- a/app/src/main/java/de/bund/zrb/model/TestSuite.java
+++ b/app/src/main/java/de/bund/zrb/model/TestSuite.java
@@ -41,6 +41,8 @@ public class TestSuite {
     private final Map<String, Boolean> afterAllEnabled = new HashMap<>();
     private final Map<String, String> afterAllDesc = new HashMap<>();
 
+    private List<Precondtion> preconditions = new ArrayList<Precondtion>();
+
     public TestSuite() {
         // leer für Gson
     }
@@ -85,6 +87,14 @@ public class TestSuite {
 
     public Map<String, String> getAfterAllDesc() {
         return afterAllDesc;
+    }
+
+    public List<Precondtion> getPreconditions() {
+        return preconditions;
+    }
+
+    public void setPreconditions(List<Precondtion> preconditions) {
+        this.preconditions = (preconditions != null) ? preconditions : new ArrayList<Precondtion>();
     }
 }
 

--- a/app/src/main/java/de/bund/zrb/ui/tabs/PreconditionListUtil.java
+++ b/app/src/main/java/de/bund/zrb/ui/tabs/PreconditionListUtil.java
@@ -1,0 +1,37 @@
+package de.bund.zrb.ui.tabs;
+
+import de.bund.zrb.model.Precondtion;
+
+/** Utility helpers to deal with precondition references inside Given lists. */
+public final class PreconditionListUtil {
+
+    /** Conventional type value used to mark a Given entry as precondition reference. */
+    public static final String TYPE_PRECONDITION_REF = "preconditionRef";
+
+    private PreconditionListUtil() {
+        // utility
+    }
+
+    /**
+     * Extract the referenced precondition id from the Given entry value (key=value&...).
+     * Returns an empty string when no id could be resolved.
+     */
+    public static String extractPreconditionId(Precondtion given) {
+        if (given == null) {
+            return "";
+        }
+        String value = given.getValue();
+        if (value == null || value.isEmpty()) {
+            return "";
+        }
+        String[] parts = value.split("&");
+        for (String part : parts) {
+            String[] kv = part.split("=", 2);
+            if (kv.length == 2 && "id".equals(kv[0])) {
+                return kv[1];
+            }
+        }
+        return "";
+    }
+}
+

--- a/app/src/main/java/de/bund/zrb/ui/tabs/PreconditionListValidator.java
+++ b/app/src/main/java/de/bund/zrb/ui/tabs/PreconditionListValidator.java
@@ -1,0 +1,55 @@
+package de.bund.zrb.ui.tabs;
+
+import de.bund.zrb.model.Precondtion;
+import de.bund.zrb.model.Precondition;
+import de.bund.zrb.service.PreconditionRegistry;
+
+import java.util.List;
+
+/** Perform lightweight validation of Given precondition references for editor tabs. */
+public final class PreconditionListValidator {
+
+    private PreconditionListValidator() {
+        // no instances
+    }
+
+    /** Validate the list or throw an {@link IllegalStateException} with a human readable message. */
+    public static void validateOrThrow(String scopeLabel, List<Precondtion> givens) {
+        if (givens == null) {
+            return;
+        }
+
+        String prefix = (scopeLabel == null || scopeLabel.trim().isEmpty())
+                ? "Preconditions"
+                : scopeLabel.trim();
+
+        for (int i = 0; i < givens.size(); i++) {
+            Precondtion given = givens.get(i);
+            if (given == null) {
+                continue;
+            }
+
+            String type = safe(given.getType());
+            if (type.isEmpty()) {
+                throw new IllegalStateException(prefix + ": Eintrag " + (i + 1) + " hat keinen Typ.");
+            }
+
+            if (PreconditionListUtil.TYPE_PRECONDITION_REF.equals(type)) {
+                String refId = PreconditionListUtil.extractPreconditionId(given);
+                if (refId == null || refId.trim().isEmpty()) {
+                    throw new IllegalStateException(prefix + ": Eintrag " + (i + 1)
+                            + " verweist auf eine Precondition ohne ID.");
+                }
+                Precondition target = PreconditionRegistry.getInstance().getById(refId.trim());
+                if (target == null) {
+                    throw new IllegalStateException(prefix + ": Unbekannte Precondition-ID " + refId + ".");
+                }
+            }
+        }
+    }
+
+    private static String safe(String value) {
+        return value == null ? "" : value.trim();
+    }
+}
+


### PR DESCRIPTION
## Summary
- add precondition lists to root, suite, and case models to persist scope preconditions
- inject a "Preconditions" tab into each scope editor with validation and auto-disable behavior
- enhance the given list editor and add utilities for parsing and validating precondition references

## Testing
- bash ./gradlew test *(fails: tools.jar not found – requires Java 8 JDK in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d6d3041b08333b5c992198c7e60e8)